### PR TITLE
Issue 4 - forcing storage account names and containers to lower case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## Types of changes
+
+* **Added** for new features.
+* **Changed** for changes in existing functionality.
+* **Deprecated** for soon-to-be removed features.
+* **Removed** for now removed features.
+* **Fixed** for any bug fixes.
+* **Security** in case of vulnerabilities.
+
+## 2019-12-02 [Changed]
+
+* Configured template to force user inputs for Storage Account and Container Names to lower case as Azure only supports lowercase for these values.

--- a/rubrik_cloudout_arm.template
+++ b/rubrik_cloudout_arm.template
@@ -61,11 +61,11 @@
     "outputs": {
         "storageAccountName": {
             "type": "String",
-            "value": "[parameters('storageAccountName')]"
+            "value": "[toLower(parameters('storageAccountName'))]"
         },
         "containerName": {
             "type": "String",
-            "value": "[parameters('containerName')]"
+            "value": "[toLower(parameters('containerName'))]"
         },
         "storageAccountKey": {
             "type": "String",

--- a/rubrik_cloudout_arm.template
+++ b/rubrik_cloudout_arm.template
@@ -39,7 +39,7 @@
                 "name": "[parameters('accountType')]"
             },
             "kind": "BlobStorage",
-            "name": "[parameters('storageAccountName')]",
+            "name": "[toLower(parameters('storageAccountName'))]",
             "apiVersion": "2018-02-01",
             "location": "[resourceGroup().location]",
             "properties": {
@@ -49,7 +49,7 @@
             "resources": [
                 {
                     "type": "blobServices/containers",
-                    "name":  "[concat('default/', parameters('containerName'))]",
+                    "name":  "[toLower(concat('default/', parameters('containerName')))]",
                     "apiVersion": "2018-03-01-preview",
                     "dependsOn": [
                         "[parameters('storageAccountName')]"


### PR DESCRIPTION
# Description

This PR simply forces the user inputs for the storage account name and container name to lower case as uppercase isn't supported.

## Related Issue

Resolves [Issue 4](https://github.com/rubrikinc/use-case-arm-template-cloudout/issues/4)

## How Has This Been Tested?

Tested by creating storage accounts on Azure with uppercase letters

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
